### PR TITLE
BAU: Update manifest with correct app name

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-  - name: di-ipv-atp-playbox
+  - name: di-ipv-core-front
     memory: 512M
     buildpack: nodejs_buildpack
     command: "node build/main.js"


### PR DESCRIPTION
The application name was incorrect in the manifest. Update to fix this.