### PR TITLE
BAU: updating redis config to use a URL.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ LICENSE
 node_modules/
 build/
 keys/
+.idea/

--- a/app/session.ts
+++ b/app/session.ts
@@ -27,7 +27,6 @@ import session from "express-session";
 import redis, { ClientOpts } from "redis";
 
 import {
-  getRedisAuthToken,
   getRedisPort,
   getRedisSessionSecret,
   getRedisSessionUrl,
@@ -43,14 +42,9 @@ const getRedisClientOptions = (): ClientOpts => {
     return { url: redisUrl };
   }
 
-  return process.env.NODE_ENV.trim() === "production"
-    ? {
-        url: "rediss://" + getRedisSessionUrl() + ":" + getRedisPort(),
-        password: getRedisAuthToken(),
-      }
-    : {
-        url: "redis://" + getRedisSessionUrl() + ":" + getRedisPort(),
-      };
+  return {
+    url: "redis://" + getRedisSessionUrl() + ":" + getRedisPort(),
+  };
 };
 
 export const getRedisClient = (): redis.RedisClient => {

--- a/config.ts
+++ b/config.ts
@@ -5,7 +5,7 @@ export const getRedisAuthToken = (): string => {
   return process.env.REDIS_AUTH_TOKEN;
 };
 export const getRedisSessionUrl = (): string => {
-  return getRedisServiceUrl() || process.env.REDIS_SESSION_URL;
+  return process.env.REDIS_SESSION_URL || getRedisServiceUrl();
 };
 export const getRedisSessionSecret = (): string => {
   return process.env.SESSION_SECRET;


### PR DESCRIPTION
- Specifying NODE_ENV env var in node container will not update the NODE_ENV retrieved with process.env weirdly.