### PR TITLE
refactor: Restructure home page into grouped sections

### DIFF
--- a/app/features/ipv/home/controller.ts
+++ b/app/features/ipv/home/controller.ts
@@ -30,10 +30,37 @@ import { SessionData } from "../../engine/api";
 const template = "ipv/home/view.njk";
 
 const getHome = (req: Request, res: Response): void => {
+  const identityEvidence = [
+    {label: "Basic information", href:"/information", text: "Enter"},
+    {label: "Passport", href:"/passport", text: "Change"},
+    {label: "Drivers Licence", href:"/driving-licence", text:"Enter"},
+    {label: "(Generic) Identity Evidence", href: "/identity-evidence", text:"Add"}
+  ]
+
+  const identityVerification = [
+    {label: "Selfie Check", href:"/selfie", text: "Enter"},
+    {label: "(Generic) Identity Verification", href: "/identity-verification", text:"Add"}
+  ]
+
+  const activityHistory = [
+    {label: "Bank Account", href: "/bank-account", text:"Add"},
+    {label: "(Generic) Identity History", href: "/identity-history", text:"Add"}
+    
+  ];
+
+  const fraud = [
+    {label: "Fraud Check", href:"/fraud-check", text: "Add"}
+  ];
+
   const sessionData: SessionData = req.session.sessionData;
+  
   return res.render(template, {
     language: req.i18n.language,
     gpg45Profile: sessionData.identityProfile,
+    identityEvidence: identityEvidence,
+    identityVerification: identityVerification,
+    activityHistory: activityHistory,
+    fraud: fraud
   });
 };
 

--- a/app/features/ipv/home/view.njk
+++ b/app/features/ipv/home/view.njk
@@ -3,63 +3,67 @@
 {% from "components/languageLink/macro.njk" import languageLink %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
 {% extends "common/layout/view.njk" %}
 {% set pageTitleName = 'pages.start.title' | translate %}
 {% block content %}
+    {% macro ipvValidationTags(evidence, emptyEvidenceText="pending") %}
+     {% if evidence.strength or evidence.validity %}
+        {{ govukTag({
+            text: "completed",
+            classes: "govuk-tag--green"
+        }) }}
+        {{ govukTag({
+            text: evidence.strength or 0,
+            classes: "govuk-tag--orange"
+        }) }}
+        {{ govukTag({
+            text: evidence.validity or 0,
+            classes: "govuk-tag--yellow"
+        }) }}
+      {% else %}
+        {{ govukTag({
+            text: emptyEvidenceText,
+            classes: "govuk-tag--blue"
+        }) }}      
+      {% endif %} 
+    {% endmacro %}
+
+    {% macro ipvSummaryList(heading, atpArray) %}
+        <h2 class="govuk-heading-m govuk-!-margin-top-5">{{ heading }}</h1>
+        {% for atp in atpArray %}
+          <div class="govuk-summary-list__row">    
+            <dt class="govuk-summary-list__key">{{ atp.label }}</dt>
+            <dd class="govuk-summary-list__value"> 
+                {{ ipvValidationTags(atp.evidence) }}          
+            </dd>     
+            <dd class="govuk-summary-list__actions">   
+                <a class="govuk-link" href="{{ atp.href }}">{{atp.text}}</a>
+            </dd>
+          </div>
+        {% endfor %}
+    {% endmacro %}
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">ATP and Orc test page</h1>
             <p>Enter all required information and then click 'Return to Orc'</p>
+
+
             {# <p><pre>{{ validations | toJSON(2) }}</pre></p> #}
             <dl class="govuk-summary-list govuk-!-margin-bottom-9">
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Identity Evidence</dt>
-                    <dd class="govuk-summary-list__value">
-                        {{ govukTag({
-                            text: "Add identity evidence",
-                            classes: "govuk-tag--blue"
-                        }) }}
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="/identity-evidence">Add</a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Identity Verification</dt>
-                    <dd class="govuk-summary-list__value">
-                        {{ govukTag({
-                            text: "Add identity verification data",
-                            classes: "govuk-tag--blue"
-                        }) }}
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="/identity-verification">Add</a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Activity History</dt>
-                    <dd class="govuk-summary-list__value">
-                        {{ govukTag({
-                            text: "Add activity history data",
-                            classes: "govuk-tag--blue"
-                        }) }}
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="/activity-history">Add</a>
-                    </dd>
-                </div>
-                <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Fraud Check</dt>
-                    <dd class="govuk-summary-list__value">
-                        {{ govukTag({
-                            text: "Add fraud check data",
-                            classes: "govuk-tag--blue"
-                        }) }}
-                    </dd>
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link" href="/fraud-check">Add</a>
-                    </dd>
-                </div>
+
+                {{ ipvSummaryList("Identity Evidence", identityEvidence)}}
+
+                {{ ipvSummaryList("Identity Verification", identityVerification)}}
+
+                {{ ipvSummaryList("Activity History", activityHistory)}}
+
+                {{ ipvSummaryList("Fraud", fraud)}}
+
+            <h2 class="govuk-heading-m govuk-!-margin-top-5">Ungrouped</h1>
+
             <div class="govuk-summary-list__row">     
             <dt class="govuk-summary-list__key">Mothers maiden name</dt>
             <dd class="govuk-summary-list__value"> 
@@ -83,6 +87,7 @@
                 <a class="govuk-link" href="/attributes?_type=mmn">{{infoText}}</a>
             </dd>
             </div>
+
             <div class="govuk-summary-list__row">     
             <dt class="govuk-summary-list__key">NINO</dt>
             <dd class="govuk-summary-list__value"> 
@@ -106,132 +111,11 @@
                 <a class="govuk-link" href="/attributes?_type=nino">{{infoText}}</a>
             </dd>
             </div>
-            <div class="govuk-summary-list__row">     
-            <dt class="govuk-summary-list__key">Basic information</dt>
-            <dd class="govuk-summary-list__value"> 
-                {% if validations.basicInfo%}
-                    {{ govukTag({
-                        text: "completed",
-                        classes: "govuk-tag--green"
-                    }) }}
-                    {{ govukTag({
-                        text: validations.basicInfo.evidence.strength or 0,
-                        classes: "govuk-tag--orange"
-                    }) }}
-                    {{ govukTag({
-                        text: validations.basicInfo.evidence.validity or 0,
-                        classes: "govuk-tag--yellow"
-                    }) }}
-                {% else %}
-                    {{ govukTag({
-                        text: "pending",
-                        classes: "govuk-tag--blue"
-                    }) }}
-                    
-                {% endif %} 
-            </dd>
-            <dd class="govuk-summary-list__actions">
-                {% set infoText = "Enter" %}
-                {%if validations.basicInfo%}
-                    {% set infoText = "Change" %} 
-                {% endif %}   
-                <a class="govuk-link" href="/information">{{infoText}}</a>
-            </dd>
-            </div>    
-            <div class="govuk-summary-list__row">    
-            <dt class="govuk-summary-list__key">Passport details</dt>
-            <dd class="govuk-summary-list__value"> 
-                {% if validations.passport%}
-                    {{ govukTag({
-                        text: "completed",
-                        classes: "govuk-tag--green"
-                    }) }}
-                    {{ govukTag({
-                        text: validations.passport.evidence.strength or 0,
-                        classes: "govuk-tag--orange"
-                    }) }}
-                    {{ govukTag({
-                        text: validations.passport.evidence.validity or 0,
-                        classes: "govuk-tag--yellow"
-                    }) }}
-                {% else %}
-                    {{ govukTag({
-                        text: "pending",
-                        classes: "govuk-tag--blue"
-                    }) }}                    
-                {% endif %} 
-            </dd>
-            <dd class="govuk-summary-list__actions">
-                {% set infoText = "Enter" %}
-                {%if validations.passport%}
-                    {% set infoText = "Change" %} 
-                {% endif %}   
-                <a class="govuk-link" href="/passport">{{infoText}}</a>
-            </dd>
-            </div>  
-            <div class="govuk-summary-list__row">    
-            <dt class="govuk-summary-list__key">Driving licence</dt>
-            <dd class="govuk-summary-list__value"> 
-                {%if validations.drivingLicence%}                    
-                    {{ govukTag({
-                        text: "completed",
-                        classes: "govuk-tag--green"
-                    }) }}     
-                    {{ govukTag({
-                        text: validations.drivingLicence.evidence.strength or 0,
-                        classes: "govuk-tag--orange"
-                    }) }}
-                    {{ govukTag({
-                        text: validations.drivingLicence.evidence.validity or 0,
-                        classes: "govuk-tag--yellow"
-                    }) }}              
-                {% else %}
-                    {{ govukTag({
-                        text: "pending",
-                        classes: "govuk-tag--blue"
-                    }) }}                     
-                {% endif %} 
-            </dd>     
-            <dd class="govuk-summary-list__actions">   
-                {% set infoText = "Enter" %}           
-                {% if validations.drivingLicence %}
-                    {% set infoText = "Change" %} 
-                {% endif %}   
-                <a class="govuk-link" href="/driving-licence">{{infoText}}</a>
-            </dd>
-            </div>        
-            <div class="govuk-summary-list__row">    
-            <dt class="govuk-summary-list__key">Bank account</dt>
-            <dd class="govuk-summary-list__value"> 
-                {%if validations.bankAccount %}  
-                    {{ govukTag({
-                        text: "completed",
-                        classes: "govuk-tag--green"
-                    }) }}
-                    {{ govukTag({
-                        text: validations.bankAccount.evidence.strength or 0,
-                        classes: "govuk-tag--orange"
-                    }) }}
-                    {{ govukTag({
-                        text: validations.bankAccount.evidence.validity or 0,
-                        classes: "govuk-tag--yellow"
-                    }) }}
-                {% else %}
-                    {{ govukTag({
-                        text: "pending",
-                        classes: "govuk-tag--blue"
-                    }) }}
-                    
-                {% endif %}           
-            <dd class="govuk-summary-list__actions">
-                {% set infoText = "Enter" %}
-                {% if validations.bankAccount %}
-                    {% set infoText = "Change" %} 
-                {% endif %}   
-                <a class="govuk-link" href="/bank-account">{{infoText}}</a>
-            </dd>
-            </div>               
             </dl>
+
+            <h2 class="govuk-heading-m govuk-!-margin-top-5">Summary</h1>
+
+            <div class="govuk-summary-list__row">     
             <dl class="govuk-summary-list govuk-!-margin-bottom-9">
                 <div class="govuk-summary-list__row">  
                     <dt class="govuk-summary-list__key">Activity history<dt>
@@ -246,6 +130,8 @@
                     <dd class="govuk-summary-list__value"> {{validations.scores.verification or 0}}</dd>
                 </div>
             </dl>
+            </div>
+
             <h2>Currently met GPG45 profile:</h2>
             <h3><span>{{gpg45Profile.description or "None"}}</span></h3>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Initial attempt at replacing manual HTML with a few macros to build up the page structure.

Data is currently directly set in the controller, this should ideally be moved into a "presenter pattern", which would also involve moving some of the template macro logic as well.

Correct display of evidence strength & validity not currently implemented, as this has been affected by the `sessionData` refactor.

There are already tickets in play for PYI-186 and children. This work should all be combined and pushed across the line together.

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-186](https://govukverify.atlassian.net/browse/PYI-186)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
