### PR TITLE
BAU: Scoring evidence.

### DIFF
--- a/app/features/engine/index.ts
+++ b/app/features/engine/index.ts
@@ -141,8 +141,8 @@ const addEvidence = async (req: Request, res: Response): Promise<void> => {
 
   if (evidence.strength || evidence.validity) {
     newEvidence.evidenceScore = {
-      strength: evidence.strength,
-      validity: evidence.validity,
+      strength: evidence.strength || 0,
+      validity: evidence.validity || 0,
     };
   }
 

--- a/app/features/engine/index.ts
+++ b/app/features/engine/index.ts
@@ -137,11 +137,14 @@ const addEvidence = async (req: Request, res: Response): Promise<void> => {
     type: evidence.type,
     evidenceData: { ...evidence.atpResponse, ...evidence.attributes },
     bundleScores: bundleScores,
-    evidenceScore: {
+  };
+
+  if (evidence.strength || evidence.validity) {
+    newEvidence.evidenceScore = {
       strength: evidence.strength,
       validity: evidence.validity,
-    },
-  };
+    };
+  }
 
   logger.info(
     `[${req.method}] ${req.originalUrl} (${sessionId}) - Adding new evidence`,


### PR DESCRIPTION
## Proposed changes

### What changed

- If we provide scores to mock, then use them. Otherwise, don't send evidenceScore object.

### Why did it change

- We want to be able to calculate evidence scores in GPG45 as well as mocking them.

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed