### PR TITLE
PYI-188: Adding in verification API.

### DIFF
--- a/app/features/engine/api/index.ts
+++ b/app/features/engine/api/index.ts
@@ -78,6 +78,7 @@ export interface IdentityEvidence {
 export interface IdentityVerification {
   type: any;
   verificationData: any;
+  verificationScore?: number;
 }
 
 export interface Activity {
@@ -151,6 +152,17 @@ export const addEvidenceApiRequest = async (
   const response = await axios.post(
     `${backendApiEndpoint}/ipv/${sessionId}/add-evidence`,
     evidence
+  );
+  return response.data;
+};
+
+export const addIdentityVerificationApiRequest = async (
+  sessionId: string,
+  verification: IdentityVerification
+): Promise<IdentityVerification> => {
+  const response = await axios.post(
+    `${backendApiEndpoint}/ipv/${sessionId}/add-identity-verification`,
+    verification
   );
   return response.data;
 };

--- a/app/middleware/logger-middleware.ts
+++ b/app/middleware/logger-middleware.ts
@@ -47,7 +47,7 @@ const logRequestMiddleware = (
   const logger: Logger = req.app.locals.logger;
   logger.debug(`[${req.method}] ${req.originalUrl}`, requestMiddlewareLabel, {
     session_id,
-    user_agent: req.useragent,
+    // user_agent: req.useragent,
   });
   next();
 };
@@ -64,7 +64,7 @@ const logErrorMiddleware = (
   logger.error(
     `[${req.method}] ${req.originalUrl}. Error ${err.message}${stack}`,
     errorMiddlewareLabel,
-    { session_id, user_agent: req.useragent }
+    { session_id /*,user_agent: req.useragent*/ }
   );
   next(err);
 };


### PR DESCRIPTION
## Proposed changes

### What changed

- Adding in a way to call the verification api when returning from the generic verification form.
- Removing `user_agent` from logs.

### Why did it change

- Calling the API to mock data.
- Removing `user_agent` from logs because it is a pain.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYI-188](https://govukverify.atlassian.net/browse/PYI-188)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
