### PR TITLE
fix: Only display evidence score if present

### DIFF
--- a/app/features/ipv/home/view.njk
+++ b/app/features/ipv/home/view.njk
@@ -10,25 +10,28 @@
 {% set pageTitleName = 'pages.start.title' | translate %}
 {% block content %}
     {% macro ipvValidationTags(evidence, emptyEvidenceText="pending") %}
-     {% if 'strength' in evidence.evidenceScore  or 'validity' in evidence.evidenceScore %}
-        {{ govukTag({
-            text: "completed",
-            classes: "govuk-tag--green"
-        }) }}
-        {{ govukTag({
-            text: evidence.evidenceScore.strength or 0,
-            classes: "govuk-tag--orange"
-        }) }}
-        {{ govukTag({
-            text: evidence.evidenceScore.validity or 0,
-            classes: "govuk-tag--yellow"
-        }) }}
+      {% if evidence.evidenceScore %}
+        {% if 'strength' in evidence.evidenceScore  or 'validity' in evidence.evidenceScore %}
+          {{ govukTag({
+              text: "completed",
+              classes: "govuk-tag--green"
+          }) }}
+          {{ govukTag({
+              text: evidence.evidenceScore.strength or 0,
+              classes: "govuk-tag--orange"
+          }) }}
+          {{ govukTag({
+              text: evidence.evidenceScore.validity or 0,
+              classes: "govuk-tag--yellow"
+          }) }}
       {% else %}
-        {{ govukTag({
-            text: emptyEvidenceText,
-            classes: "govuk-tag--blue"
-        }) }}
+          {{ govukTag({
+              text: emptyEvidenceText,
+              classes: "govuk-tag--blue"
+          }) }}
       {% endif %} 
+    {% endif %}
+
     {% endmacro %}
 
     {% macro identityVerificationValidationTags(evidence, emptyEvidenceText="pending") %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Attempting to display evidence strength when evidence score wasn't present was causing a nunjucks template rendering error.
 
## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
