### PR TITLE
BAU: fix summary scores

### DIFF
--- a/app/features/ipv/home/controller.ts
+++ b/app/features/ipv/home/controller.ts
@@ -70,6 +70,18 @@ const getHome = (req: Request, res: Response): void => {
 
   const sessionData: SessionData = req.session.sessionData;
 
+  let activityHistoryScore;
+  if (sessionData.activityChecks) {
+    activityHistoryScore = Math.max(...sessionData.activityChecks
+      .map((evidence) => evidence.activityHistoryScore))
+  }
+
+  let identityVerificationScore;
+  if (sessionData.activityChecks) {
+    identityVerificationScore = Math.max(...sessionData.identityVerification
+      .map((evidence) => evidence.verificationScore))
+  }
+
   return res.render(template, {
     language: req.i18n.language,
     gpg45Profile: sessionData.identityProfile,
@@ -80,6 +92,8 @@ const getHome = (req: Request, res: Response): void => {
     evidenceArray: sessionData.identityEvidence,
     identityVerificationEvidenceArray: sessionData.identityVerification,
     activityHistoryEvidenceArray: sessionData.activityChecks,
+    activityHistoryScore: activityHistoryScore,
+    identityVerificationScore: identityVerificationScore,
   });
 };
 

--- a/app/features/ipv/home/view.njk
+++ b/app/features/ipv/home/view.njk
@@ -281,7 +281,7 @@
             <dl class="govuk-summary-list govuk-!-margin-bottom-9">
                 <div class="govuk-summary-list__row">  
                     <dt class="govuk-summary-list__key">Activity history<dt>
-                    <dd class="govuk-summary-list__value"> {{validations.scores.activityHistory or 0}}</dd>
+                    <dd class="govuk-summary-list__value"> {{activityHistoryScore or 0}}</dd>
                 </div>
                 <div class="govuk-summary-list__row">  
                     <dt class="govuk-summary-list__key">Identity fraud<dt>
@@ -289,7 +289,7 @@
                 </div>
                 <div class="govuk-summary-list__row">  
                     <dt class="govuk-summary-list__key">Verification<dt>
-                    <dd class="govuk-summary-list__value"> {{validations.scores.verification or 0}}</dd>
+                    <dd class="govuk-summary-list__value"> {{identityVerificationScore or 0}}</dd>
                 </div>
             </dl>
             </div>


### PR DESCRIPTION
## Proposed changes

### What changed

**_Currently fraud evidence isn't being saved into the sessionData???_**

Searches through the list of evidences and displays the highest score

### Why did it change

Was previously not working and defaulting to displaying 0

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
