### PR TITLE
feat: Show sessionData json on home page

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -114,6 +114,7 @@ const createApp = (): express.Application => {
           "https://www.google-analytics.com",
           "https://ssl.google-analytics.com",
         ],
+        styleSrc: ["'self'", "https://cdnjs.cloudflare.com"],
         objectSrc: ["'none'"],
         connectSrc: ["'self'", "https://www.google-analytics.com"],
       },

--- a/app/features/engine/index.ts
+++ b/app/features/engine/index.ts
@@ -23,7 +23,7 @@ import {
 } from "./api";
 import Logger from "../../utils/logger";
 
-import { SessionData } from "../engine/api"
+import { SessionData } from "../engine/api";
 
 const logger: Logger = new Logger();
 
@@ -82,7 +82,9 @@ export const startNewSession = async (
 
   req.session.userId = sessionId;
 
-  req.session.sessionData = { sessionId: createdSession.sessionId } as SessionData
+  req.session.sessionData = {
+    sessionId: createdSession.sessionId,
+  } as SessionData;
 
   req.session.autoInput = { items: [] };
 

--- a/app/features/ipv/home/controller.ts
+++ b/app/features/ipv/home/controller.ts
@@ -34,6 +34,8 @@ import {
 } from "../../engine/api";
 import { INTERNAL_SERVER_ERROR } from "http-status-codes";
 
+import * as hljs from "highlight.js";
+
 const template = "ipv/home/view.njk";
 
 const getHome = (req: Request, res: Response): void => {
@@ -69,6 +71,10 @@ const getHome = (req: Request, res: Response): void => {
   const fraud = [{ label: "Fraud Check", href: "/fraud-check", text: "Add" }];
 
   const sessionData: SessionData = req.session.sessionData;
+  const debugData: any = hljs.default.highlight(
+    `${JSON.stringify(req.session.sessionData, null, 2)}`,
+    { language: "json" }
+  ).value;
 
   let activityHistoryScore;
   if (sessionData.activityChecks) {
@@ -94,6 +100,7 @@ const getHome = (req: Request, res: Response): void => {
     activityHistoryEvidenceArray: sessionData.activityChecks,
     activityHistoryScore: activityHistoryScore,
     identityVerificationScore: identityVerificationScore,
+    debugData: debugData,
   });
 };
 

--- a/app/features/ipv/home/view.njk
+++ b/app/features/ipv/home/view.njk
@@ -200,7 +200,6 @@
             <h1 class="govuk-heading-xl">ATP and Orc test page</h1>
             <p>Enter all required information and then click 'Return to Orc'</p>
 
-            {# <p><pre>{{ validations | toJSON(2) }}</pre></p> #}
             <dl class="govuk-summary-list">
               {{ ipvSummaryList("Identity Evidence", identityEvidence)}}
             </dl>
@@ -293,6 +292,23 @@
                 </div>
             </dl>
             </div>
+
+
+            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.2.0/styles/stackoverflow-light.min.css">
+            {{ govukAccordion({
+                id: "accordion-default",
+                items: [
+                    {
+                        heading: {
+                            text: "Debug Data"
+                        },
+                        content: {
+                            html:  "<pre><code>" + debugData + "</code></pre>" 
+                        }
+                    }
+                ]
+            }) }}
+
 
             <h2>Currently met GPG45 profile:</h2>
             <h3><span>{{gpg45Profile.description or "None"}}</span></h3>

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@godaddy/terminus": "^4.4.1",
+    "@types/highlight.js": "^10.1.0",
     "axios": "^0.21.1",
     "babel-loader": "^8.0.6",
     "cfenv": "^1.2.4",
@@ -51,6 +52,7 @@
     "express-validator": "^6.6.0",
     "govuk-frontend": "^3.7.0",
     "helmet": "^3.21.2",
+    "highlight.js": "^11.2.0",
     "http-status-codes": "^1.3.2",
     "i18next": "^19.5.2",
     "i18next-fs-backend": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,6 +1012,13 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/highlight.js@^10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-10.1.0.tgz#89bb0c202997d7a90a07bd2ec1f7d00c56bb90b4"
+  integrity sha512-77hF2dGBsOgnvZll1vymYiNUtqJ8cJfXPD6GG/2M0aLRc29PkvB7Au6sIDjIEFcSICBhCh2+Pyq6WSRS7LUm6A==
+  dependencies:
+    highlight.js "*"
+
 "@types/http-cache-semantics@*":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
@@ -4551,6 +4558,11 @@ hide-powered-by@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hide-powered-by/-/hide-powered-by-1.1.0.tgz#be3ea9cab4bdb16f8744be873755ca663383fa7a"
   integrity sha512-Io1zA2yOA1YJslkr+AJlWSf2yWFkKjvkcL9Ni1XSUqnGLr/qRQe2UI3Cn/J9MsJht7yEVCe0SscY1HgVMujbgg==
+
+highlight.js@*, highlight.js@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.2.0.tgz#a7e3b8c1fdc4f0538b93b2dc2ddd53a40c6ab0f0"
+  integrity sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Add highlight.js to render JSON data in a styled way
- Show transformed sessionData as debugData in template

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add a debug accordion onto the homepage, styled using [highlight js](https://highlightjs.org/)
<!-- Describe the changes in detail - the "what"-->

### Screenshots

![Screenshot from 2021-08-27 09-56-14](https://user-images.githubusercontent.com/196695/131101504-9513437c-c9d2-4f94-b7e8-6d3531294da1.png)

### Why did it change

It's difficult to understand and remember the data that has been collected. To help with debugging of the GPG45 profile matching, it's easier if we can see the raw data that has been used.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
